### PR TITLE
UCSStrメソッドチェーン対応 #9

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/kanaria_core" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/kanaria_extern_c" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/core/tests/example_sentence.rs
+++ b/core/tests/example_sentence.rs
@@ -35,3 +35,11 @@ fn example_sentence_4() {
     assert_eq!(UCSStr::from_str(zenkaku).narrow().to_string(), hankaku.to_string());
     assert_eq!(UCSStr::from_str(hankaku).wide().to_string(), zenkaku.to_string());
 }
+
+#[test]
+fn example_sentence_5() {
+    let source = "吾輩は😺猫である😺";
+    let expect = "吾輩ﾊ😺猫ﾃﾞｱﾙ😺";
+
+    assert_eq!(expect.to_string(), UCSStr::from_str(source).katakana().narrow().to_string());
+}

--- a/core/tests/narrow_wide.rs
+++ b/core/tests/narrow_wide.rs
@@ -1,4 +1,4 @@
-use kanaria::{UCSChar, UCSStr};
+use kanaria::UCSChar;
 use kanaria::utils::WidthUtils;
 
 #[test]


### PR DESCRIPTION
Rustの文字列の仕様（charはUnicodeスカラ、StringはUTF-8バイト配列）にあわせるとこうせざるを得なかった。
各Converterに実装したto_string()の出番がなくなってしまった…