### PR TITLE
fix invalid repo url

### DIFF
--- a/kanaria_core/Cargo.toml
+++ b/kanaria_core/Cargo.toml
@@ -3,7 +3,7 @@ name = "kanaria"
 version = "0.2.0"
 authors = ["osamu <46447427+sam-osamu@users.noreply.github.com>"]
 
-repository = "https://github.com/sam-osamu/com.kanaria"
+repository = "https://github.com/samunohito/kanaria"
 readme = "../README.md"
 description = "This library provides functions such as hiragana, katakana, half-width and full-width mutual conversion and discrimination."
 license = "MIT"


### PR DESCRIPTION
Crate.io repository URL  is 404, so I fixed it.
https://crates.io/crates/kanaria/0.2.0
